### PR TITLE
scripts: Imrpove shebang usage

### DIFF
--- a/scripts/generate_fcm.py
+++ b/scripts/generate_fcm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Author: Sebastiano Barezzi <barezzisebastiano@gmail.com>
 # Version: 1.3
 

--- a/scripts/manifest_creator.py
+++ b/scripts/manifest_creator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, pathlib
 import xml.etree.ElementTree as ET
 

--- a/scripts/manifest_default_branch_verifier.py
+++ b/scripts/manifest_default_branch_verifier.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, sys, os, json
 import xml.etree.ElementTree as ET
 

--- a/scripts/regulatory_overlay_creator.py
+++ b/scripts/regulatory_overlay_creator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 
 # Define the base directory and overlay information

--- a/scripts/replace_camera_sepolicy.sh
+++ b/scripts/replace_camera_sepolicy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Replace vendor.camera.aux.packagelist and vendor_persist_camera_prop
 # Run as follows, ./device/motorola/targets/scripts/replace_camera_sepolicy.sh
 

--- a/scripts/sort_vintf_manifest.py
+++ b/scripts/sort_vintf_manifest.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import xml.etree.ElementTree as ET
 

--- a/scripts/update_rom_device_symlinks.sh
+++ b/scripts/update_rom_device_symlinks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROM_DIR="rom"
 DEVICE_DIR="devices"


### PR DESCRIPTION
In this pull request, I've added the possibility for the user to directly execute the Python scripts from their console without having to call `python` before. Most importantly, all of these changes are now furthermore _generic_ and safe to run on any system considering the fact that, for Bash script(s), it does not hardcode the shell's path to `/bin/bash` anymore but uses the more _universal_ `/usr/bin/env bash`.
 